### PR TITLE
Support selection of outer elements

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -4,6 +4,7 @@ function main() {
   const status = document.getElementById("status");
   const startButton = document.getElementById("start");
   const onlyEmphasisCheckbox = document.getElementById("only-emphasis");
+  const onlyParagraphsCheckbox = document.getElementById("only-paragraphs");
 
   const setElement = (el) => {
     const tags = [];
@@ -27,6 +28,10 @@ function main() {
   onlyEmphasisCheckbox.onchange = (ev) => {
     onlyEmphasis = ev.target.checked;
   }
+  let onlyParagraphs = onlyParagraphsCheckbox.checked;
+  onlyParagraphsCheckbox.onchange = (ev) => {
+    onlyParagraphs = ev.target.checked;
+  }
   const start = () => {
     startButton.disabled = true;
     picker.start({
@@ -36,10 +41,14 @@ function main() {
         startButton.disabled = false;
       },
       elementFilter: (el) => {
-        if (!onlyEmphasis) {
-          return true;
+        if (onlyEmphasis) {
+          return ['I', 'B'].includes(el.tagName);
         }
-        return ['I', 'B'].includes(el.tagName);
+        else if (onlyParagraphs) {
+          const paragraph = el.closest("p, h1")
+          return paragraph ?? false
+        }
+        return true;
       }
     });
   };

--- a/example/index.html
+++ b/example/index.html
@@ -23,5 +23,6 @@
     <div id="status">Click "start" to activate the picker.</div>
     <button id="start">Start</button>
     <label><input id="only-emphasis" type="checkbox" /> Only emphasis tags</label>
+    <label><input id="only-paragraphs" type="checkbox" /> Only paragraphs</label>
   </body>
 </html>


### PR DESCRIPTION
Extended elementFilter so that a returned element will be used as the target. This is useful if we want to be able to select a certain type of elements, but not it's children. For example paragraphs, but not <b>, <i> etc. inside of it.